### PR TITLE
Retro Diffusion research + K-Centroid/grid-detection implementation plan

### DIFF
--- a/docs/RETRO-DIFFUSION.md
+++ b/docs/RETRO-DIFFUSION.md
@@ -1,0 +1,144 @@
+# Retro Diffusion: competitive research, decision, and direction
+
+*Researched 2026-07-14. Companion doc: [`plan-prompt.md`](./plan-prompt.md) is the
+execution handoff prompt derived from this analysis.*
+
+## Why we looked
+
+[retrodiffusion.ai](https://retrodiffusion.ai/) — specifically its free
+[Pixel Art Fixer](https://www.retrodiffusion.ai/tools/pixel-art-fixer/) tool —
+is the closest commercial product to what pixegen does: AI generation of
+game-ready pixel art with hard palette/grid guarantees, plus repair of
+AI-generated or corrupted pixel art. This doc records what they built, how,
+what's open source, and what we decided to take from it.
+
+## Who they are
+
+Retro Diffusion is a solo-founder product by **Astropulse (Cody Claus)**. It
+began as a paid [Aseprite extension](https://astropulse.itch.io/retrodiffusion)
+shipping custom-trained Stable Diffusion pixel-art models, and grew into a web
+app + paid developer API. Models are trained on licensed pixel art with artist
+consent (also their ethics/marketing positioning). Inference is hosted on
+[Runware](https://runware.ai/blog/retro-diffusion-creating-authentic-pixel-art-with-ai-at-scale),
+whose case study on them is the best single "lessons learned" source.
+
+## Their stack, as best we can tell
+
+- **Generation**: custom fine-tunes. Current flagship `RD_FLUX` is a fine-tune
+  of the FLUX architecture; they explicitly moved off the earlier
+  many-specialized-LoRAs approach to one model whose ~28 styles are selected by
+  prompting alone. Older SD-era models still back some cheaper tiers
+  (RD Fast/Plus/Pro families, $0.03–$0.18 per image).
+- **Post-processing**: proprietary pipeline built around their **K-Centroid**
+  downscaling algorithm plus color quantization. The founder's core thesis,
+  from the Runware case study:
+
+  > "Getting AI models to generate pixel art is mostly about dataset, data
+  > preparation, and post processing."
+
+  Even their meticulously trained models **cannot hold strict color limits** —
+  palette conformance is enforced in post, not in the model.
+- **Pixel Art Fixer**: the productized version of their open-source
+  `pixeldetector` — a `standard` variant (Rust port of the Python original) and
+  a `neural` variant (model-based reconstruction). Free, rate-limited API
+  endpoint (`/v1/pixel-fixer/*`).
+
+## The algorithms (from MIT-licensed source)
+
+Read from [`Astropulse/pixeldetector`](https://github.com/Astropulse/pixeldetector)
+(**MIT**, Python, ~1 file):
+
+1. **Pixel grid detection** — compute per-pixel RGB difference between
+   horizontally and vertically adjacent pixels; sum the differences along each
+   axis to get a 1-D "edge energy" profile per axis; run peak-finding
+   (scipy `find_peaks`) on each profile; the **median spacing between
+   consecutive peaks** is the true pixel size on that axis. Dividing image
+   dimensions by the spacing recovers the native resolution of an upscaled or
+   JPEG-mangled pixel-art image.
+2. **K-Centroid downscale** — for each output pixel, take the corresponding
+   source tile and run k-means on its colors (k≈2), then emit the **most
+   common centroid**. Noise-robust where naive nearest/average downscales blur
+   and mode-based downscales speckle on noisy AI output. Also published
+   standalone as [`K-Centroid-Aseprite`](https://github.com/Astropulse/K-Centroid-Aseprite) (MIT).
+3. **Palette-size prediction** — elbow method: quantize at increasing k,
+   measure total squared distortion, pick the k where the improvement rate
+   peaks (diminishing returns). Used to auto-choose a color count with no
+   user input.
+
+Related but **unlicensed** (read for ideas, do not copy code):
+[`sd-palettize`](https://github.com/Astropulse/sd-palettize) (A1111 palettize
+extension), [`Retro-Diffusion/api-examples`](https://github.com/Retro-Diffusion/api-examples)
+(API docs/examples).
+
+## Their API surface (design ideas worth stealing)
+
+From the api-examples repo — `POST /v1/inferences` with:
+
+- `prompt_style` — a named style registry (their equivalent of our recipes;
+  validates that interface as the primary API surface).
+- `check_cost: true` — free dry-run returning exact price, generating nothing.
+- `input_palette` (base64 palette image) + `return_pre_palette` — constrain
+  output colors and get both the quantized and raw versions back.
+- `reference_images` (up to 9, RD Pro) — pass prior outputs to keep a
+  character consistent across new generations. Same concept as our Characters
+  tab's `image=` conditioning chain.
+- Animation from a **start frame**: `rd_advanced_animation__*` takes any
+  pixel-art `input_image` + an action (`walking`, `idle`, `attack`, …) and
+  returns frames — a stronger consistency strategy than batching all frames in
+  one strip prompt.
+- Wang-tile tilesets from one prompt (`rd_tile__tileset`).
+- Free/cheap post-processing "edit tools" as API endpoints: `color_reducer`,
+  `palette_converter`, `k_centroid_downscale`, `pixel_correction`,
+  `background_remover`.
+- `async: true` + task polling for long jobs.
+
+Pricing for market context: $0.03–0.18/image, $0.07–0.25/animation,
+$0.10/tileset.
+
+## What this means for pixegen
+
+**Their success validates our architecture.** We cannot train models (we
+resell Pollinations/OpenAI), but the founder's own account says model choice is
+the *smaller* half — dataset aside, quality comes from post-processing, which
+is exactly the half we control (`src/core/`) and the half our eval loop
+optimizes. Our lever and their lever are the same lever.
+
+### Decisions
+
+1. **Port K-Centroid into `src/core/quantize.js`** as a third downscale
+   strategy (MIT — port with attribution). Evaluate it against the current
+   `downscaleMode` via the eval sweep before changing any recipe defaults.
+2. **Implement pixel-grid detection in core** and use it two ways:
+   - a new offline `pixegen fix` command (Pixel Art Fixer parity: detect grid →
+     K-Centroid downscale to native res → optional palette reduction), also
+     exposed as an MCP tool;
+   - an advisory validation signal (detected source grid vs. requested sprite
+     scale disagreement = the model didn't draw on the grid we asked for).
+3. **Elbow-method auto color count** for free-palette output (`--colors auto`).
+4. **Backlog, not now** (recorded so we don't lose them):
+   - start-frame-conditioned animation (generate frame 1, then condition each
+     subsequent frame on it) — likely the biggest consistency win for sheets;
+   - `check_cost`-style dry-run and a styles/recipes listing endpoint if we
+     ever ship a hosted API;
+   - `return_pre_palette` equivalent in CLI/MCP output (we already store both
+     in Dexie);
+   - neural repair variant — requires a trained model; out of reach and out of
+     scope.
+5. **Do not copy** from `sd-palettize` or `api-examples` (no license); the
+   MIT repos (`pixeldetector`, `K-Centroid-Aseprite`) are fair game.
+
+The detailed execution plan lives in [`plan-prompt.md`](./plan-prompt.md).
+
+## Sources
+
+- https://www.retrodiffusion.ai/tools/pixel-art-fixer/
+- https://runware.ai/blog/retro-diffusion-creating-authentic-pixel-art-with-ai-at-scale
+- https://github.com/Astropulse/pixeldetector (MIT, 354★)
+- https://github.com/Astropulse/K-Centroid-Aseprite (MIT)
+- https://github.com/Astropulse/sd-palettize (no license)
+- https://github.com/Retro-Diffusion/api-examples (no license)
+- https://astropulse.gitbook.io/retro-diffusion (docs; `llms.txt` index, every
+  page fetchable as `.md`)
+- https://astropulse.itch.io/retrodiffusion (devlogs)
+- https://replicate.com/retro-diffusion/rd-plus
+- https://github.com/oliexe/Retro-Diffusion-Unity (community Unity integration)

--- a/docs/plan-prompt.md
+++ b/docs/plan-prompt.md
@@ -1,0 +1,184 @@
+# Plan prompt: K-Centroid downscale, grid detection, and `pixegen fix`
+
+*Hand this file to the implementing agent as its task prompt. Background and
+rationale: [`RETRO-DIFFUSION.md`](./RETRO-DIFFUSION.md). Written 2026-07-14.*
+
+---
+
+You are implementing three post-processing capabilities in the pixegen repo,
+ported/adapted from Retro Diffusion's MIT-licensed `pixeldetector`
+(https://github.com/Astropulse/pixeldetector — read the source first; it is
+one short Python file). Read `CLAUDE.md` and `docs/RETRO-DIFFUSION.md` before
+writing code. Work phase by phase, in order; each phase compiles, passes
+`npm test`, and gets its own commit before the next begins.
+
+## Hard constraints
+
+- **Core purity**: everything in `src/core/` operates on plain
+  `{ data: Uint8ClampedArray, width, height }` rasters with **no DOM, canvas,
+  or Node APIs**. Implement k-means and peak-finding by hand — **no new npm
+  dependencies** (no scipy equivalents; the needed subset is ~40 lines).
+- **No behavior change by default**: existing recipes and the default pipeline
+  must produce byte-identical output after your changes. New strategies are
+  opt-in; recipe defaults only change later, on eval-sweep evidence.
+- **Tests**: Playwright specs. Pure-core tests run in Node with direct ESM
+  imports and no `page` fixture — copy the pattern in `tests/exporters.spec.js`.
+  Any test touching eval findings must set `PIXEGEN_FINDINGS_PATH` to a temp
+  path. Never hit the live API in tests; mock with `PIXEGEN_API_BASE` if a
+  test needs the network path at all.
+- **MCP**: `bin/pixegen-mcp.js` must never write to stdout (protocol channel);
+  log to stderr.
+- Attribute ported algorithms: one comment line, e.g.
+  `// Ported from Astropulse/pixeldetector (MIT).`
+
+## Phase 1 — K-Centroid downscale in core
+
+**`src/core/quantize.js`**: add
+`downscaleKCentroid(sourceData, targetW, targetH, { centroids = 2 } = {})`
+with the same contract as the existing `downscaleMode` / `downscaleAverage`
+(raster in, raster out). Algorithm: for each output pixel, take its source
+tile, k-means the tile's opaque RGB colors to `centroids` clusters (a few
+iterations of Lloyd's is enough; seed centroids deterministically, e.g.
+min/max-luma colors, so output is reproducible), emit the most common
+centroid. Preserve the alpha handling the existing downscalers use (look at
+how `downscaleMode` treats transparent source pixels and match it).
+
+**`src/core/pipeline.js`**: add a `downscale` option to `processSourceRaster`
+(`'mode' | 'average' | 'k-centroid'`). Default stays exactly today's behavior:
+`enhanced` pipeline → `'mode'`, `classic` → `'average'`; an explicit
+`options.downscale` overrides. Export a `DOWNSCALE_OPTIONS` list next to
+`PIPELINE_MODES` for UI pickers.
+
+**Plumbing** (opt-in surfaces only):
+- `src/core/recipes.js`: recipes may carry a `downscale` key; do **not** set it
+  on existing recipes yet.
+- `bin/pixegen.js`: `--downscale <mode>` flag on `generate`/`sheet`/`tileset`,
+  passed through like `--dithering` is (note how the CLI distinguishes
+  "unset" from "override recipe default").
+- `bin/pixegen-mcp.js`: add the enum to the generation tool schemas.
+- Browser: add a Downscale select where the Pipeline/Dithering selects live in
+  `src/App.jsx`, driven by `DOWNSCALE_OPTIONS`; wire it into `CompareLab.jsx`
+  config axes so A/B can test it.
+- The eval loop: make sure `pixegen eval run --challenger '{"downscale":"k-centroid"}'`
+  works (check how `src/node/eval-store.js` / the eval runner map challenger
+  keys to `processSourceRaster` options — if it forwards settings generically,
+  this is free).
+
+**Tests** (`tests/kcentroid.spec.js`): build a synthetic ground-truth sprite
+(e.g. 8×8 with 4 distinct colors), upscale it ×8 (use `upscaleRaster` from
+`src/core/raster.js`), add deterministic per-pixel noise (±12 per channel,
+seeded PRNG), then assert `downscaleKCentroid` recovers ≥95% of pixels exactly
+while `downscaleAverage` on the same input recovers fewer (guards that the new
+code actually beats the baseline on the case it exists for). Also test alpha
+preservation and a non-integer scale factor (65×63 source → 8×8).
+
+## Phase 2 — Pixel grid detection in core
+
+New module **`src/core/gridsize.js`**:
+
+- `detectPixelGrid(raster)` →
+  `{ spacingX, spacingY, nativeW, nativeH, confidence }`.
+- Algorithm (from pixeldetector): per axis, sum the RGB distance between each
+  pixel and its neighbor into a 1-D edge-energy profile; find peaks (local
+  maxima above a prominence threshold with a minimum distance — implement a
+  small `findPeaks(values, { minProminence, minDistance })` helper, exported
+  for testing); spacing = median gap between consecutive peaks; `nativeW =
+  round(width / spacingX)`. `confidence` should reflect peak-gap regularity
+  (e.g. fraction of gaps within ±1 of the median) so callers can ignore
+  low-confidence detections; return `confidence: 0` with spacing 1 when no
+  usable peaks exist (photos, flat images).
+
+**Tests** (`tests/gridsize.spec.js`): known sprites upscaled ×3, ×5, ×7 with
+noise → assert detected spacing; a blurred upscale (simulate JPEG softness by
+box-blurring the upscaled image) → still detects; a random-noise image →
+low confidence; a native-res sprite (spacing 1) → doesn't false-positive a
+larger grid.
+
+## Phase 3 — `pixegen fix` command + MCP tool
+
+**CLI** (`bin/pixegen.js`):
+
+```
+pixegen fix <input> -o <out.png> [--colors auto|N] [--palette <profile>] [--scale <WxH>]
+```
+
+Offline, no network. Flow: decode input via `decodeImage` in `src/node/png.js`
+(handles PNG and JPEG) → `detectPixelGrid` → `downscaleKCentroid` to the
+detected native size (`--scale` overrides detection; warn on stderr when
+confidence is low) → optional color step:
+- `--palette <profile>`: quantize with `quantizeOklab` against that
+  `PALETTE_PROFILES` entry;
+- `--colors N`: k-means the image to N colors;
+- `--colors auto`: elbow method (Phase 3a below);
+- neither: keep detected colors as-is.
+
+Print the detection result (spacing, native size, confidence) and write the
+PNG via the existing encode path. Log the run through `src/node/run-log.js`
+like other commands.
+
+**Phase 3a — elbow method** in `src/core/quantize.js`:
+`estimateColorCount(raster, { maxColors = 128 } = {})` — k-means at increasing
+k, total squared distortion, return the k at the elbow (peak of the
+improvement-rate second difference). Sample pixels (e.g. cap at ~10k, strided)
+to keep it fast on large images.
+
+**MCP** (`bin/pixegen-mcp.js`): tool `fix_pixel_art` taking a file path (match
+how existing tools accept inputs/outputs) with the same options; returns the
+detection metadata and output path.
+
+**Tests**: CLI-level spec that runs `node bin/pixegen.js fix` on a fixture
+built in the test (write a temp PNG of an upscaled noisy sprite using the
+node png helpers), asserts output dimensions equal the native size and the
+process exits 0. Unit test for `estimateColorCount` on a synthetic image with
+a known color count (e.g. exactly 6 colors + noise → estimate in [5, 8]).
+
+## Phase 4 — Advisory validation signal
+
+In `src/node/generate.js`'s validation gate: after decoding the source (before
+downscale), run `detectPixelGrid` on the source raster and compare implied
+native size to the requested sprite size. On high-confidence disagreement
+(detected native res differs from requested by >25% on either axis), record a
+**warning** in the run log (`src/node/run-log.js`, a `validation` event) — do
+**not** fail or trigger the retry on it; we gather signal first. Keep this out
+of `core/validate.js`'s pass/fail checks for now (grid analysis applies to the
+pre-downscale source, which those checks never see); a comment in
+`validate.js` pointing at the new signal is enough.
+
+## Phase 5 — Eval sweep (needs live API; skip gracefully if unavailable)
+
+`source .env` first (funded `POLLINATIONS_API_KEY`; anonymous tier 401s).
+Invoke the **`/eval-sweep` skill** with the `downscale` axis: champion =
+current ideal settings per target, challenger = same + `downscale:
+"k-centroid"`, on at least the `nes` and `gameboy` targets. Judge by looking
+at the PNGs, record verdicts with `pixegen eval record`. Only if results are
+decisive, set `downscale: "k-centroid"` on the winning recipes and cite the
+trials in the recipe description (follow the existing citation style in
+`recipes.js`). If the API is unreachable, note it and leave recipes untouched.
+
+## Phase 6 — Docs
+
+- `CLAUDE.md`: add `fix` to the command list; extend the core module map
+  (gridsize.js, new quantize exports, `downscale` option).
+- `README.md`: add `pixegen fix` if the README lists CLI commands.
+- `docs/last-sesh.md`: rewrite per the session-doc convention.
+- `docs/LESSONS.md`: only if a durable lesson emerged (e.g. k-centroid vs mode
+  eval outcome).
+
+## Out of scope (do not build; already in the backlog in RETRO-DIFFUSION.md)
+
+Start-frame-conditioned animation, hosted-API features (`check_cost`, styles
+endpoint), neural repair, any change to providers or generation requests.
+
+## Verification before finishing
+
+1. `npm test` — full suite green.
+2. `node bin/pixegen.js fix <fixture>` on a real upscaled sprite → correct
+   native size, clean output (eyeball the PNG).
+3. `PIXEGEN_API_BASE=<mock> node bin/pixegen.js generate "a knight" --downscale k-centroid -o /tmp/k.png`
+   → succeeds; same command without the flag → byte-identical to pre-change
+   output for a fixed mock image.
+4. Browser: dev server up, Downscale select visible, A/B tab can pit mode vs
+   k-centroid.
+
+Commit per phase, push the branch, and open a draft PR describing what changed
+and linking `docs/RETRO-DIFFUSION.md`.


### PR DESCRIPTION
Two docs from the Retro Diffusion competitive research:

- **docs/RETRO-DIFFUSION.md** — what retrodiffusion.ai runs on (FLUX fine-tune, Runware inference), the MIT-licensed pixeldetector algorithms behind their Pixel Art Fixer (K-Centroid downscale, pixel-grid detection, elbow-method palette sizing), their API design, and the decisions on what pixegen adopts vs. backlogs.
- **docs/plan-prompt.md** — a self-contained handoff prompt for an implementing agent: port K-Centroid into core, add grid detection, ship an offline `pixegen fix` command + MCP tool, wire an advisory validation signal, and eval-sweep the new downscaler before touching recipe defaults.

No code changes in this PR — docs only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)